### PR TITLE
feat: dream

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -147,7 +147,11 @@ export default class NovaJournalPlugin extends Plugin {
             removeDateHeadingInEditor(editor);
             
             const date = new Date();
-            const basePrompt = this.promptService.getPromptForDate(this.settings.promptStyle as PromptStyle, date);
+            const { prompt: basePrompt } = this.promptService.getContextAwarePrompt(
+                this.settings.promptStyle as PromptStyle,
+                date,
+                editor.getValue()
+            );
 
             const wasInserted = await this.promptInsertionService.insertTodaysPromptWithDuplicateCheck(
                 editor,
@@ -174,7 +178,7 @@ export default class NovaJournalPlugin extends Plugin {
     }
 
     private cyclePromptStyle(): void {
-        const order: PromptStyle[] = ['reflective', 'gratitude', 'planning'];
+        const order: PromptStyle[] = ['reflective', 'gratitude', 'planning', 'dreams'];
         const idx = order.indexOf(this.settings.promptStyle as PromptStyle);
         const safeIdx = idx >= 0 ? idx : 0;
         const next = order[(safeIdx + 1) % order.length];

--- a/prompt/PromptRegistry.ts
+++ b/prompt/PromptRegistry.ts
@@ -1,4 +1,4 @@
-export type PromptStyle = 'reflective' | 'gratitude' | 'planning';
+export type PromptStyle = 'reflective' | 'gratitude' | 'planning' | 'dreams';
 
 export const promptPacks: Record<PromptStyle, string[]> = {
   reflective: [
@@ -18,6 +18,12 @@ export const promptPacks: Record<PromptStyle, string[]> = {
     'Which obstacle might block me, and how will I handle it?',
     'What one habit will I reinforce tomorrow?',
     'What would make tomorrow feel successful?',
+  ],
+  dreams: [
+    'Describe the most vivid part of your dream and how it felt.',
+    'What symbols or recurring themes appeared in your dream?',
+    'If this dream was telling you something, what might it be?',
+    'What emotions linger from the dream as you wake up?',
   ],
 };
 

--- a/prompt/PromptService.ts
+++ b/prompt/PromptService.ts
@@ -1,4 +1,5 @@
 import { promptPacks, PromptStyle } from './PromptRegistry';
+import type { MoodData } from '../services/rendering/FrontmatterService';
 
 export class PromptService {
   getPromptForDate(style: PromptStyle, date: Date): string {
@@ -6,6 +7,39 @@ export class PromptService {
     const seed = this.generateDateSeed(style, date);
     const index = seed % prompts.length;
     return prompts[index];
+  }
+
+  getContextAwarePrompt(
+    preferredStyle: PromptStyle,
+    date: Date,
+    noteText?: string,
+    moodData?: Partial<MoodData>
+  ): { style: PromptStyle; prompt: string } {
+    const style = this.selectStyleFromContext(preferredStyle, noteText, moodData);
+    return { style, prompt: this.getPromptForDate(style, date) };
+  }
+
+  private selectStyleFromContext(
+    preferredStyle: PromptStyle,
+    noteText?: string,
+    moodData?: Partial<MoodData>
+  ): PromptStyle {
+    const text = (noteText || '').toLowerCase();
+
+    // Heuristics: if user mentions dreams, switch to dreams
+    const indicatesDream = /\b(dream|rêve|reves|rêves|nightmare|cauchemar)\b/i.test(text);
+    if (indicatesDream) {
+      return 'dreams';
+    }
+
+    // Heuristics based on mood tags/emotions
+    const tags = (moodData?.tags || []).map((t) => t.toLowerCase());
+    const emotions = (moodData?.dominant_emotions || []).map((e) => e.toLowerCase());
+    if (tags.includes('sleep') || tags.includes('dreams') || emotions.includes('curious')) {
+      return 'dreams';
+    }
+
+    return preferredStyle;
   }
 
   private generateDateSeed(style: string, date: Date): number {

--- a/services/editor/PromptInsertionService.ts
+++ b/services/editor/PromptInsertionService.ts
@@ -15,7 +15,11 @@ export class PromptInsertionService {
     removeDateHeadingInEditor(editor);
     
     const date = new Date();
-    const basePrompt = this.promptService.getPromptForDate(this.settings.promptStyle as PromptStyle, date);
+    const { prompt: basePrompt } = this.promptService.getContextAwarePrompt(
+      this.settings.promptStyle as PromptStyle,
+      date,
+      editor.getValue()
+    );
 
     if (this.isDuplicatePrompt(editor, basePrompt)) {
       new Notice('Nova Journal: this prompt already exists in this note.');

--- a/ui/SettingsTab.ts
+++ b/ui/SettingsTab.ts
@@ -309,7 +309,7 @@ export class NovaJournalSettingTab extends PluginSettingTab {
 					? "Stored locally. Only OpenAI is supported for now."
 					: "Key format looks unusual. It should start with sk- for OpenAI."
 			)
-			.addText((text) =>
+			.addText((text) => {
 				text
 					.setPlaceholder("sk-...")
 					.setValue(this.plugin.settings.aiApiKey)
@@ -317,12 +317,14 @@ export class NovaJournalSettingTab extends PluginSettingTab {
 						try {
 							this.plugin.settings.aiApiKey = value;
 							await this.plugin.saveSettings();
-							this.display();
 						} catch (error) {
 							new Notice("Failed to save API key");
 						}
-					})
-			)
+					});
+				text.inputEl.addEventListener("blur", () => {
+					this.display();
+				});
+			})
 			.addButton((button) =>
 				button.setButtonText("Test").onClick(async () => {
 					await ApiTester.testOpenAIConnection(
@@ -359,6 +361,7 @@ export class NovaJournalSettingTab extends PluginSettingTab {
 					reflective: "Reflective",
 					gratitude: "Gratitude",
 					planning: "Planning",
+					dreams: "Dreams",
 				});
 				dropdown.setValue(this.plugin.settings.promptStyle);
 				dropdown.onChange(async (value) => {
@@ -386,13 +389,15 @@ export class NovaJournalSettingTab extends PluginSettingTab {
 						try {
 							this.plugin.settings.promptTemplate = value;
 							await this.plugin.saveSettings();
-							this.display();
 						} catch (error) {
 							new Notice("Failed to save template");
 						}
 					});
 				textArea.inputEl.cols = 40;
 				textArea.inputEl.rows = 4;
+				textArea.inputEl.addEventListener("blur", () => {
+					this.display();
+				});
 			});
 
 		this.renderTemplatePresetSection(containerEl);
@@ -476,7 +481,7 @@ export class NovaJournalSettingTab extends PluginSettingTab {
 					? "e.g., gpt-4o-mini. Only OpenAI models are supported for now."
 					: "Model name may not be an OpenAI model (e.g., gpt-4o-mini)."
 			)
-			.addText((text) =>
+			.addText((text) => {
 				text
 					.setPlaceholder("gpt-4o-mini")
 					.setValue(this.plugin.settings.aiModel)
@@ -485,12 +490,14 @@ export class NovaJournalSettingTab extends PluginSettingTab {
 							this.plugin.settings.aiModel =
 								value || "gpt-4o-mini";
 							await this.plugin.saveSettings();
-							this.display();
 						} catch (error) {
 							new Notice("Failed to save model");
 						}
-					})
-			);
+					});
+				text.inputEl.addEventListener("blur", () => {
+					this.display();
+				});
+			});
 
 		new Setting(containerEl)
 			.setName("Fallback OpenAI model")


### PR DESCRIPTION
### **User description**
## Summary
Enhance SettingsTab functionality with improved event handling and new prompt option

## Key Changes
- Enhance SettingsTab functionality with improved event handling and new prompt option
- Enhance Prompt Functionality with Context-Aware Mood Integration

## Impact
- Risk: Low
- Affected areas: prompt; main.ts; services

## Testing
- Manual: run Nova Journal commands and validate template/duplicate-prevention

---

### Diagram

```mermaid
flowchart LR
  Main["NovaJournalPlugin (main.ts)"] --> Settings["NovaJournalSettingTab (ui/SettingsTab.ts)"]
  Main --> Service["PromptService (prompt/PromptService.ts)"]
  Service --> Registry["PromptRegistry (prompt/PromptRegistry.ts)"]
```

<details><summary><h3>Files Touched</h3></summary>

- main.ts (modified)
- prompt/PromptRegistry.ts (modified)
- prompt/PromptService.ts (modified)
- services/editor/PromptInsertionService.ts (modified)
- ui/SettingsTab.ts (modified)

</details>

## Meta
- +68 / -13, 81 changes

## Checklist
- [x] Scope is small and focused


___

### **PR Type**
Enhancement


___

### **Description**
- Add context-aware prompt generation (mood & text)

- Introduce new "dreams" prompt style and pack

- Use context-aware prompts on insertion and main flow

- Improve SettingsTab input handling and UI refresh


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Main["NovaJournalPlugin (main.ts)"] --> PromptService["PromptService (prompt/PromptService.ts)"]
  PromptService --> Registry["PromptRegistry (prompt/PromptRegistry.ts)"]
  Main --> Insertion["PromptInsertionService (services/editor/PromptInsertionService.ts)"]
  UI["SettingsTab (ui/SettingsTab.ts)"] --> Main
  Registry -- "provides styles" --> PromptService
  PromptService -- "returns context-aware prompt" --> Insertion
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.ts</strong><dd><code>Use context-aware prompts and include 'dreams'</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.ts

<ul><li>Replace getPromptForDate call with getContextAwarePrompt usage<br> <li> Pass editor content to prompt selection for context-awareness<br> <li> Add <code>dreams</code> to cycle order of prompt styles</ul>


</details>


  </td>
  <td><a href="https://github.com/mariepop13/obsidian-nova-journal/pull/13/files#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PromptRegistry.ts</strong><dd><code>New `dreams` prompt style and prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prompt/PromptRegistry.ts

<ul><li>Add <code>dreams</code> to <code>PromptStyle</code> type union<br> <li> Add a <code>dreams</code> prompt pack with several dream-focused prompts</ul>


</details>


  </td>
  <td><a href="https://github.com/mariepop13/obsidian-nova-journal/pull/13/files#diff-38a4fe0f75d5cbd60f88e1339871077a3094d3bfb429b0142fedcf2e97540426">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PromptService.ts</strong><dd><code>Context-aware prompt selection service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prompt/PromptService.ts

<ul><li>Add <code>getContextAwarePrompt</code> method returning style and prompt<br> <li> Add heuristics <code>selectStyleFromContext</code> using note text and mood<br> <li> Import <code>MoodData</code> type to enable mood-aware decisions</ul>


</details>


  </td>
  <td><a href="https://github.com/mariepop13/obsidian-nova-journal/pull/13/files#diff-79f472ee76830bff9835676e40019aa355dd33e0798b16eeebf5e80cea36b2f7">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PromptInsertionService.ts</strong><dd><code>Insert context-aware daily/prompts into editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/editor/PromptInsertionService.ts

<ul><li>Use <code>getContextAwarePrompt</code> with editor text for prompt insertion<br> <li> Ensure duplicate-check logic remains unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/mariepop13/obsidian-nova-journal/pull/13/files#diff-dbdbf920dd66359a9217713c667a4d74723ea318e6bc20732e0d22d3a2a76753">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SettingsTab.ts</strong><dd><code>Settings UI: blur handling and new dropdown option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ui/SettingsTab.ts

<ul><li>Add <code>dreams</code> option to daily prompt style dropdown<br> <li> Add <code>blur</code> event listeners to text inputs and textareas to refresh <br>display<br> <li> Refactor text handlers to use try/catch and avoid immediate display <br>calls</ul>


</details>


  </td>
  <td><a href="https://github.com/mariepop13/obsidian-nova-journal/pull/13/files#diff-3f6bfa9b432de66ede21aafce087a45e72405c02000de9ebd19c4685d9ef6f82">+16/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

enable_custom_labels: False
model: gpt-5-mini
fallback_models: ['gpt-5-mini', 'gpt-4o-mini']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 2
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
ai_timeout: 120
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
custom_model_max_tokens: -1
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_auto_approval: False
auto_approve_for_low_review_effort: -1
auto_approve_for_no_suggestions: False
ensure_ticket_compliance: False
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
model_reasoning: gpt-5-mini
model_weak: gpt-5-mini

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
include_generated_by_header: True
enable_large_pr_handling: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
