### PR TITLE
🔧 Update PR Agent workflow to use custom GitHub token

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -31,7 +31,7 @@ jobs:
         uses: qodo-ai/pr-agent@main
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.PR_AGENT_GITHUB_TOKEN }}
       
       - name: Comment on failure
         if: failure()


### PR DESCRIPTION
Replace default github.token with PR_AGENT_GITHUB_TOKEN secret for enhanced permissions and better integration with PR Agent bot functionality.